### PR TITLE
fix(installer): installation if throwing a fatal error when installin…

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -5,11 +5,17 @@ import { fileSystem } from "@speedy/node-core";
 const gitRoot = fileSystem.findFileRecursively(".git");
 
 if (!gitRoot) {
-	console.log("Not a GIT Repository");
-	process.exit(0);
+	console.error("Not a GIT Repository");
+	process.exit();
 }
 
-const hooksPath = path.join(gitRoot!, ".git", "hooks");
+const gitPath = path.join(gitRoot!, ".git");
+if (!lstatSync(gitPath).isDirectory()) {
+	console.warn(".git is not a folder. Commit message hook will not be installed.");
+	process.exit();
+}
+
+const hooksPath = path.join(gitPath, "hooks");
 const commitMsgHookPath = path.join(hooksPath, "commit-msg");
 let fileStat: Stats | undefined;
 


### PR DESCRIPTION
…g in a git worktree

We'll now display a warning when the installer tries to run in git worktree. Ie, `.git` is a file and not a directory.

Closes: #15